### PR TITLE
Create LDIF format of ansible_inventory schema

### DIFF
--- a/ldap/README.asciidoc
+++ b/ldap/README.asciidoc
@@ -10,7 +10,7 @@ Included is an LDIF export so you can get an idea of the LDAP structure.
 - groups need to be groupOfNames
 - you can have a group inside a group. These wil be listed as children
 - The directory is extended with a custom schema created by @jpmens. The file
-  is included as ansible.schema.
+  is included as ansible.schema and ansible.ldif for use with OLC.
 
 example output
 --------------

--- a/ldap/ansible.ldif
+++ b/ldap/ansible.ldif
@@ -49,14 +49,11 @@
 # 
 #	1.3.6.1.4.1.7637.70.1.2                         LDAP AttributeTypes
 #
-
-
 # ansibleVar: ansible_ssh_host=localhost
-
+dn: cn=ansible,cn=schema,cn=config
+objectClass: olcSchemaConfig
+cn: core
 olcattributetypes: ( 1.3.6.1.4.1.7637.70.1.2.1 NAME 'ansibleVar' DESC 'A variable=value setting for an Ansible host' EQUALITY caseIgnoreMatch SUBSTR caseIgnoreSubstringsMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.15{1024} )
-
 olcattributetypes: ( 1.3.6.1.4.1.7637.70.1.2.2 NAME 'ansibleGroupVar' DESC 'A variable=value setting for an Ansible Group' EQUALITY caseIgnoreMatch SUBSTR caseIgnoreSubstringsMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.15{1024} )
-
 olcobjectclasses: ( 1.3.6.1.4.1.7637.70.1.1.1 NAME 'ansibleHost' DESC 'Ansible host entry' SUP top AUXILIARY MAY ( ansibleVar  ) )
-
 olcobjectclasses: ( 1.3.6.1.4.1.7637.70.1.1.2 NAME 'ansibleGroup' DESC 'Ansible group entry' SUP top AUXILIARY MAY ( ansibleGroupVar  ) )

--- a/ldap/ansible.ldif
+++ b/ldap/ansible.ldif
@@ -1,0 +1,62 @@
+## ansible.schema Copyright (c) 2013 by Jan-Piet Mens <jp()mens.de>
+##
+## Redistribution and use in source and binary forms, with or without
+## modification, are permitted provided that the following conditions
+## are met:
+##
+## 1. Redistributions of source code must retain the above copyright
+##    notice, this list of conditions and the following disclaimer.
+##
+## 2. Redistributions in binary form must reproduce the above copyright
+##    notice, this list of conditions and the following disclaimer in the
+##    documentation and/or other materials provided with the distribution.
+##
+## 3. All advertising materials mentioning features or use of this software
+##    must display the following acknowledgement:
+##      This product includes software developed by Jan-Piet Mens and his
+##      contributors.
+##
+## 4. Neither the name of the Author nor the names of its contributors
+##    may be used to endorse or promote products derived from this software
+##    without specific prior written permission.
+##
+## THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+## ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+## IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+## ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+## FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+## DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+## OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+## HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+## LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+## OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+## SUCH DAMAGE.
+##
+
+# OpenLDAP schema file for Ansible. Requires core schema. In particular,
+# we propose to use `device' as a structural objectclass, which brings
+# the following attribute types:
+#
+#   MUST ( cn )
+#   MAY  ( serialNumber $ seeAlso $ owner $ ou $ o $ l $ description )
+# 
+#
+# The OID numbers used herein are officially registered, and I have reserved
+# these ranges for use by Ansible:
+#
+#	1.3.6.1.4.1.7637.70                     Ansible
+#	1.3.6.1.4.1.7637.70.1.1                         LDAP ObjectClasses
+# 
+#	1.3.6.1.4.1.7637.70.1.2                         LDAP AttributeTypes
+#
+
+
+# ansibleVar: ansible_ssh_host=localhost
+
+olcattributetypes: ( 1.3.6.1.4.1.7637.70.1.2.1 NAME 'ansibleVar' DESC 'A variable=value setting for an Ansible host' EQUALITY caseIgnoreMatch SUBSTR caseIgnoreSubstringsMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.15{1024} )
+
+olcattributetypes: ( 1.3.6.1.4.1.7637.70.1.2.2 NAME 'ansibleGroupVar' DESC 'A variable=value setting for an Ansible Group' EQUALITY caseIgnoreMatch SUBSTR caseIgnoreSubstringsMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.15{1024} )
+
+olcobjectclasses: ( 1.3.6.1.4.1.7637.70.1.1.1 NAME 'ansibleHost' DESC 'Ansible host entry' SUP top AUXILIARY MAY ( ansibleVar  ) )
+
+olcobjectclasses: ( 1.3.6.1.4.1.7637.70.1.1.2 NAME 'ansibleGroup' DESC 'Ansible group entry' SUP top AUXILIARY MAY ( ansibleGroupVar  ) )


### PR DESCRIPTION
Since `slapd.conf` is being [deprecated in the most recent OpenLDAP release](http://www.openldap.org/doc/admin24/slapdconfig.html), I rearranged the schema into the `ldif` format. This should work with any `ldapmodify` or `ldapadd` command. See [Zytrax's explanation of OLC](http://www.zytrax.com/books/ldap/ch6/slapd-config.html) for more information.